### PR TITLE
fix: support updating guild status

### DIFF
--- a/api/tests/guilds/test_update_guild.py
+++ b/api/tests/guilds/test_update_guild.py
@@ -1,0 +1,93 @@
+import json
+
+from rustic_ai.core.agents.testutils import EchoAgent
+from rustic_ai.core.guild.builders import AgentBuilder
+from rustic_ai.core.guild.dsl import AgentSpec, GuildSpec
+
+
+def test_update_guild_status(client):
+    agent1: AgentSpec = AgentBuilder(EchoAgent).set_name("Agent1").set_description("First agent").build_spec()
+
+    guild_spec = GuildSpec(
+        name="TestGuild",
+        description="A guild for status update testing",
+        properties={
+            "storage": {
+                "class": "rustic_ai.core.messaging.storage.InMemoryStorage",
+                "properties": {},
+            }
+        },
+        agents=[agent1],
+    )
+    json_data = guild_spec.model_dump_json()
+    data = json.loads(json_data)
+    post_response = client.post("/api/guilds", json=data, headers={"Content-Type": "application/json"})
+
+    assert post_response.status_code == 201
+    assert "id" in post_response.json()
+
+    guild_id = post_response.json()["id"]
+
+    get_response = client.get(f"/api/guilds/{guild_id}")
+    assert get_response.status_code == 200
+    assert get_response.json().get("status") == "active"
+
+    update_response = client.patch(
+        f"/api/guilds/{guild_id}/status", json={"status": "stopped"}, headers={"Content-Type": "application/json"}
+    )
+
+    assert update_response.status_code == 200
+    assert update_response.json().get("status") == "stopped"
+
+    get_updated_response = client.get(f"/api/guilds/{guild_id}")
+    assert get_updated_response.status_code == 200
+    assert get_updated_response.json().get("status") == "stopped"
+
+    update_response = client.patch(
+        f"/api/guilds/{guild_id}/status", json={"status": "archived"}, headers={"Content-Type": "application/json"}
+    )
+
+    assert update_response.status_code == 200
+    assert update_response.json().get("status") == "archived"
+
+    get_archived_response = client.get(f"/api/guilds/{guild_id}")
+    assert get_archived_response.status_code == 200
+    assert get_archived_response.json().get("status") == "archived"
+
+
+def test_update_guild_status_invalid_guild_id(client):
+    update_data = {"status": "stopped"}
+    response = client.patch(
+        "/api/guilds/nonexistent_guild_id/status", json=update_data, headers={"Content-Type": "application/json"}
+    )
+
+    assert response.status_code == 404
+
+
+def test_update_guild_status_invalid_status(client):
+    agent1: AgentSpec = AgentBuilder(EchoAgent).set_name("Agent1").set_description("First agent").build_spec()
+
+    guild_spec = GuildSpec(
+        name="TestGuild2",
+        description="Another guild for testing invalid status",
+        properties={
+            "storage": {
+                "class": "rustic_ai.core.messaging.storage.InMemoryStorage",
+                "properties": {},
+            }
+        },
+        agents=[agent1],
+    )
+    json_data = guild_spec.model_dump_json()
+    data = json.loads(json_data)
+    post_response = client.post("/api/guilds", json=data, headers={"Content-Type": "application/json"})
+
+    assert post_response.status_code == 201
+    guild_id = post_response.json()["id"]
+
+    update_data = {"status": "invalid_status"}
+    response = client.patch(
+        f"/api/guilds/{guild_id}/status", json=update_data, headers={"Content-Type": "application/json"}
+    )
+
+    assert response.status_code == 400

--- a/core/src/rustic_ai/core/guild/dsl.py
+++ b/core/src/rustic_ai/core/guild/dsl.py
@@ -195,6 +195,7 @@ class GuildSpec(BaseModel):
         agents (list[AgentSpec]): A list of agents in the guild.
         dependency_map (Dict[str, DependencySpec]): A mapping for guild's dependency to resolver class.
         routes (RoutingSlip): The routes to be attached to every message coming in the guild.
+        status (str): The status of the guild, e.g., "active", "stopped", "archived".
     """
 
     model_config = ConfigDict(str_strip_whitespace=True)
@@ -204,6 +205,7 @@ class GuildSpec(BaseModel):
     description: Annotated[str, Field(min_length=1)]
     properties: Dict[str, Any] = {}
     agents: list[AgentSpec] = []
+    status: str = "active"  # Using string instead of enum to avoid circular imports
 
     # A mapping for guild's dependency to resolver class
     dependency_map: Dict[str, DependencySpec] = {}

--- a/core/src/rustic_ai/core/guild/metastore/guild_store.py
+++ b/core/src/rustic_ai/core/guild/metastore/guild_store.py
@@ -4,7 +4,7 @@ from sqlalchemy import Engine
 from sqlmodel import Session, select
 
 from ..dsl import APT, AgentSpec, GuildSpec
-from .models import AgentModel, GuildModel
+from .models import AgentModel, GuildModel, GuildStatus
 
 
 class GuildStore:
@@ -35,6 +35,34 @@ class GuildStore:
             session.add(guild_model)
             session.commit()
             session.refresh(guild_model)
+        return guild_model
+
+    def update_guild_status(self, guild_id: str, status: GuildStatus) -> Optional[GuildModel]:
+        """
+        Update a guild's status.
+
+        Args:
+            guild_id (str): The ID of the guild to update
+            status (GuildStatus): The new status value to set
+
+        Returns:
+            Optional[GuildModel]: The updated guild model, or None if the guild was not found
+
+        Raises:
+            ValueError: If the guild is not found
+        """
+        with Session(self.engine) as session:
+            guild_model = GuildModel.get_by_id(session, guild_id)
+
+            if not guild_model:
+                raise ValueError(f"Guild with ID {guild_id} not found")
+
+            guild_model.status = status
+
+            session.add(guild_model)
+            session.commit()
+            session.refresh(guild_model)
+
         return guild_model
 
     def list_guilds(self) -> Sequence[GuildModel]:

--- a/core/src/rustic_ai/core/guild/metastore/models.py
+++ b/core/src/rustic_ai/core/guild/metastore/models.py
@@ -1,3 +1,4 @@
+from enum import Enum
 from typing import Dict, List, Optional
 
 import shortuuid
@@ -11,6 +12,14 @@ from rustic_ai.core.guild.dsl import KeyConstants as GSKC
 from rustic_ai.core.guild.execution import SyncExecutionEngine
 from rustic_ai.core.messaging.core.message import AgentTag, RoutingRule, RoutingSlip
 from rustic_ai.core.utils.priority import Priority
+
+
+class GuildStatus(str, Enum):
+    """Status values for Guild models."""
+
+    ACTIVE = "active"
+    STOPPED = "stopped"
+    ARCHIVED = "archived"
 
 
 class GuildRoutes(SQLModel, table=True):
@@ -175,7 +184,7 @@ class GuildModel(SQLModel, table=True):
     backend_config: dict = Field(sa_column=Column(MutableDict.as_mutable(JSON(none_as_null=True)), default={}))
 
     dependency_map: dict = Field(sa_column=Column(MutableDict.as_mutable(JSON(none_as_null=True)), default={}))
-
+    status: GuildStatus = Field(default=GuildStatus.ACTIVE)
     routes: list[GuildRoutes] = Relationship(
         back_populates="guild",
         sa_relationship_kwargs={"cascade": "all", "lazy": "joined"},
@@ -218,6 +227,7 @@ class GuildModel(SQLModel, table=True):
             id=guild_spec.id,
             name=guild_spec.name,
             description=guild_spec.description,
+            status=guild_spec.status,
             execution_engine=exec_engine,
             backend_module=backend.backend_module,
             backend_class=backend.backend_class,
@@ -246,6 +256,7 @@ class GuildModel(SQLModel, table=True):
             id=self.id,
             name=self.name,
             description=self.description,
+            status=self.status,
             agents=[agent.to_agent_spec() for agent in self.agents],
             properties={
                 GSKC.EXECUTION_ENGINE: self.execution_engine,

--- a/core/tests/guild/metastore/test_guild_store.py
+++ b/core/tests/guild/metastore/test_guild_store.py
@@ -5,7 +5,7 @@ from rustic_ai.core.guild.builders import AgentBuilder, GuildBuilder
 from rustic_ai.core.guild.dsl import AgentSpec, DependencySpec
 from rustic_ai.core.guild.metastore.database import Metastore
 from rustic_ai.core.guild.metastore.guild_store import GuildStore
-from rustic_ai.core.guild.metastore.models import GuildModel
+from rustic_ai.core.guild.metastore.models import GuildModel, GuildStatus
 from rustic_ai.core.messaging.core.message import (
     AgentTag,
     FunctionalTransformer,
@@ -45,6 +45,24 @@ class TestGuildStore:
         assert gm1.id == "guild1"
         guild = store.get_guild(gm1.id)
         assert guild.id == "guild1"
+
+    def test_update_guild_status(self, engine, guild):
+        store = GuildStore(engine)
+        guild_model = store.add_guild(guild)
+        assert guild_model.status.value == "active"  
+
+        store.update_guild_status(guild.id, GuildStatus.STOPPED)
+
+        updated_guild = store.get_guild(guild.id)
+        assert updated_guild is not None
+        assert updated_guild.status.value == "stopped"
+
+        store.update_guild_status(guild.id, GuildStatus.ARCHIVED)
+        updated_guild = store.get_guild(guild.id)
+        assert updated_guild.status.value == "archived"
+
+        with pytest.raises(ValueError):
+            store.update_guild_status("nonexistent_guild", GuildStatus.ACTIVE)
 
     def test_list_guilds(self, engine, guild):
         store = GuildStore(engine)


### PR DESCRIPTION
## Change
- support updating guild status

## Screenshots
### Get guild details API
<img width="1402" alt="Screenshot 2025-05-18 at 8 31 22 PM" src="https://github.com/user-attachments/assets/910e47c3-e358-47d9-a5f5-c85c628b8b69" />

### Update guild status API
Success
<img width="1405" alt="Screenshot 2025-05-18 at 8 30 56 PM" src="https://github.com/user-attachments/assets/721ef636-0605-430c-8289-97fcde643053" />
Invalid status
<img width="1409" alt="Screenshot 2025-05-18 at 8 30 01 PM" src="https://github.com/user-attachments/assets/47c28d8a-81ec-4219-b9fe-70e75a62616d" />
Invalid guildId
<img width="1413" alt="Screenshot 2025-05-18 at 8 30 28 PM" src="https://github.com/user-attachments/assets/3384b43e-3040-47ae-bc8b-43acde2d061b" />
