### PR TITLE
feat(core): tolerate missing agent classes in AgentSpec deserialization

### DIFF
--- a/core/src/rustic_ai/core/guild/builders.py
+++ b/core/src/rustic_ai/core/guild/builders.py
@@ -653,6 +653,28 @@ class GuildBuilder:
 
         return GuildSpec(**spec_dict)
 
+    def validate_deployable(self) -> GuildSpec:
+        """
+        Build the GuildSpec and strictly validate that every agent's class (and
+        the classes of nested typed props) is importable in the current environment.
+
+        Agent-spec deserialization is tolerant by default: an agent whose package is
+        not installed degrades to an opaque props container rather than raising, so
+        that isolated environments can load a spec without importing agent classes
+        they do not run. This helper opts into fail-fast validation and is intended
+        for environments that are expected to have every agent package installed
+        (e.g. CI or authoring tooling). The ``require_agent_class`` context flows to
+        every nested AgentSpec (and to a GuildManagerAgent's embedded guild_spec).
+
+        Returns:
+            GuildSpec: The validated, deployable GuildSpec instance.
+
+        Raises:
+            pydantic.ValidationError: If any agent's class is not importable.
+        """
+        guild_spec = self.build_spec()
+        return GuildSpec.model_validate(guild_spec.model_dump(), context={"require_agent_class": True})
+
     @classmethod
     def from_spec(cls, guild_spec: GuildSpec) -> "GuildBuilder":
         """

--- a/core/src/rustic_ai/core/guild/dsl.py
+++ b/core/src/rustic_ai/core/guild/dsl.py
@@ -36,6 +36,25 @@ class BaseAgentProps(BaseModel):
         return f"{cls.__module__}.{cls.__name__}"
 
 
+class OpaqueProps(BaseAgentProps):
+    """
+    Fallback container for an agent's properties when the agent's implementation
+    class is NOT importable in the current environment.
+
+    Enables isolated per-agent deployments: an environment that has only a subset
+    of agent packages installed (e.g. a core-only GuildManagerAgent or API server,
+    or a per-agent worker container) can still deserialize, hold, route, and
+    re-persist a full GuildSpec without importing agent classes it does not run.
+    The raw properties dict is preserved verbatim (``extra="allow"``) so it
+    round-trips losslessly back to storage / the wire.
+
+    Only ever produced for agents the current environment does not own; the owning
+    environment, which has the class, types the props into the concrete props model.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+
 APT = TypeVar("APT", bound=BaseAgentProps)
 
 
@@ -258,25 +277,47 @@ class AgentSpec(BaseModel, Generic[APT]):
 
     @model_validator(mode="before")
     @classmethod
-    def pre_build_validator(cls, data):
+    def pre_build_validator(cls, data, info):
+
+        if not isinstance(data, dict):
+            # Revalidation from an already-built instance — nothing to resolve.
+            return data
 
         class_name = data.get("class_name")
         agent_class: Type
 
         if not class_name:
             raise ValueError("class_name is required")
-        else:
-            try:
-                agent_class = get_class_from_name(class_name)
 
-                # Loading the class from the string to avoid circular imports
+        # Strict resolution is opt-in via a validation context; the default is
+        # tolerant. Tolerance lets an environment that lacks an agent's package
+        # (a core-only GuildManagerAgent or API server, or an isolated per-agent
+        # worker container) still deserialize, hold, route, and re-persist a full
+        # GuildSpec without importing agent classes it does not run. Pass
+        # ``context={"require_agent_class": True}`` (e.g. from CI/authoring, where
+        # all classes are installed) to restore fail-fast behaviour.
+        require_class = bool(info.context.get("require_agent_class")) if info and info.context else False
 
-                agent_base_class = get_class_from_name("rustic_ai.core.guild.Agent")
-            except Exception as e:
-                raise ValueError(f"Invalid class name: {class_name}") from e
+        try:
+            agent_class = get_class_from_name(class_name)
 
-            if not issubclass(agent_class, agent_base_class):
-                raise ValueError(f"Class {class_name} is not a subclass of Agent")
+            # Loading the class from the string to avoid circular imports
+            agent_base_class = get_class_from_name("rustic_ai.core.guild.Agent")
+        except ImportError as e:
+            # The agent's package is not importable in this environment. This is
+            # the isolation signal: degrade the properties to a lossless opaque
+            # container instead of failing, unless strict resolution was requested.
+            if require_class:
+                raise ValueError(f"Agent class '{class_name}' is not importable in this environment") from e
+            data["properties"] = cls._to_opaque_props(data.get("properties"))
+            return data
+        except Exception as e:
+            # Malformed name, or module present but attribute missing — a genuine
+            # spec error, not an isolation artifact.
+            raise ValueError(f"Invalid class name: {class_name}") from e
+
+        if not issubclass(agent_class, agent_base_class):
+            raise ValueError(f"Class {class_name} is not a subclass of Agent")
 
         properties_type: Type[BaseAgentProps] = agent_class.__annotations__[MetaclassConstants.AGENT_PROPS_TYPE] or BaseAgentProps  # type: ignore
 
@@ -286,13 +327,41 @@ class AgentSpec(BaseModel, Generic[APT]):
             if not properties or type(properties) is BaseAgentProps:
                 data["properties"] = properties_type()
             elif properties and isinstance(properties, dict):
-                data["properties"] = properties_type.model_validate(properties)
+                try:
+                    data["properties"] = properties_type.model_validate(properties)
+                except ImportError as e:
+                    # A nested class referenced by the props (e.g. a toolset/plugin
+                    # ``kind`` or a ``ToolSpec.parameter_class``) is not importable
+                    # here — typically a peer agent's plugin package. Degrade the whole
+                    # props subtree to a lossless opaque container unless strict
+                    # resolution was requested. Genuine prop errors surface as
+                    # ValidationError (pydantic wraps ValueError/AssertionError, not
+                    # ImportError) and still propagate.
+                    if require_class:
+                        raise ValueError(
+                            f"A class referenced by the properties of '{class_name}' "
+                            f"is not importable in this environment"
+                        ) from e
+                    data["properties"] = cls._to_opaque_props(properties)
             elif not isinstance(properties, properties_type):
                 raise ValueError(f"Properties must be an instance of {properties_type}")
         elif properties and type(properties) is not BaseAgentProps:
             raise ValueError(f"Agent {class_name} does not accept properties")
 
         return data
+
+    @staticmethod
+    def _to_opaque_props(properties) -> "OpaqueProps":
+        """Coerce raw properties into an OpaqueProps without importing the agent class."""
+        if properties is None:
+            return OpaqueProps()
+        if isinstance(properties, OpaqueProps):
+            return properties
+        if isinstance(properties, dict):
+            return OpaqueProps.model_validate(properties)
+        if isinstance(properties, BaseModel):
+            return OpaqueProps.model_validate(properties.model_dump())
+        raise ValueError("properties must be a dict or BaseModel when the agent class is unavailable")
 
     @classmethod
     def get_pydantic_generic_type(cls) -> Type[BaseAgentProps]:
@@ -343,9 +412,6 @@ class GuildSpec(BaseModel):
     routes: RoutingSlip = Field(default_factory=RoutingSlip)
 
     gateway: Optional[GatewayConfig] = None
-
-    def __init__(self, **data):
-        super().__init__(**data)
 
     def add_agent_spec(self, agent: AgentSpec):
         if agent not in self.agents:

--- a/core/src/rustic_ai/core/guild/execution/utils.py
+++ b/core/src/rustic_ai/core/guild/execution/utils.py
@@ -5,7 +5,7 @@ from rustic_ai.core.guild.agent_ext.depends.dependency_resolver import (
     DependencyResolver,
     DependencySpec,
 )
-from rustic_ai.core.guild.dsl import AgentSpec, GuildSpec
+from rustic_ai.core.guild.dsl import AgentSpec, GuildSpec, OpaqueProps
 from rustic_ai.core.guild.g2g.boundary_agent import BoundaryAgent
 from rustic_ai.core.messaging.core.client import Client
 from rustic_ai.core.messaging.core.messaging_interface import MessagingInterface
@@ -22,6 +22,20 @@ def build_agent_from_spec(
     machine_id: int,
     organization_id: Optional[str] = None,
 ) -> Agent:
+
+    # Spec deserialization is tolerant by default: an agent whose class (or a nested
+    # plugin/toolset class referenced by its props) is not importable has its props
+    # degraded to an opaque container, so environments can hold/route peers they do not
+    # run and a core-only GuildManagerAgent can ship specs onward. This is the point
+    # where an agent is instantiated in the environment that actually runs it. If the
+    # props are still opaque here, something was missing when the spec was loaded, so
+    # re-validate strictly: this rebuilds the real typed props using the classes
+    # installed here (e.g. a spec that arrived opaque from a core-only manager), and
+    # fails fast with a clear error if this environment is genuinely missing something
+    # the agent it is about to run requires. A spec whose props are already typed is
+    # left untouched so any live plugin instances it carries keep their identity.
+    if isinstance(agent_spec.properties, OpaqueProps):
+        agent_spec = AgentSpec.model_validate(agent_spec.model_dump(), context={"require_agent_class": True})
 
     agent_class = get_agent_class(agent_spec.class_name)
 

--- a/core/tests/guild/dsl/test_agent_spec.py
+++ b/core/tests/guild/dsl/test_agent_spec.py
@@ -1,12 +1,22 @@
 from pydantic import ValidationError
 import pytest
 
-from rustic_ai.core.guild.dsl import AgentSpec, BaseAgentProps
+from rustic_ai.core.guild import Agent
+from rustic_ai.core.guild import agent as agent_ns
+from rustic_ai.core.guild.dsl import (
+    AgentSpec,
+    BaseAgentProps,
+    GuildSpec,
+    OpaqueProps,
+)
+from rustic_ai.core.guild.metastore.models import AgentModel
 from rustic_ai.core.utils.basic_class_utils import get_qualified_class_name
+from rustic_ai.core.utils.model_class import ModelClass
 
 from core.tests.guild.sample_agents import (
     DemoAgentGenericWithoutTypedParams,
     DemoAgentProps,
+    MessageDataType,
 )
 from core.tests.guild.simple_agent import SimpleAgent
 
@@ -14,6 +24,19 @@ from core.tests.guild.simple_agent import SimpleAgent
 class DummyAgentProps(BaseAgentProps):
     prop1: str
     prop2: int
+
+
+class NestedResolvingProps(BaseAgentProps):
+    # Mimics a real plugin/toolset config: an FQCN string is resolved to a class at
+    # validation time (ImportError if the referenced package is not installed), the
+    # same way ReActAgentConfig.toolset / ToolSpec.parameter_class resolve nested kinds.
+    param_class: ModelClass
+
+
+class NestedResolvingAgent(Agent[NestedResolvingProps]):
+    @agent_ns.processor(MessageDataType)
+    def handle_message(self, ctx: agent_ns.ProcessContext[MessageDataType]):
+        pass
 
 
 class TestAgentSpec:
@@ -141,3 +164,150 @@ class TestAgentSpec:
                 description="First agent",
                 class_name=get_qualified_class_name(DummyAgentProps),
             )
+
+
+# Properties of a foreign agent whose implementation package is not installed here.
+FOREIGN_PROPS = {
+    "model": "gpt-4o",
+    "temperature": 0.7,
+    "toolset": {"kind": "not_installed.pkg.Toolset", "nested": {"a": [1, 2, 3]}},
+}
+
+
+def _foreign_agent_data() -> dict:
+    return {
+        "id": "foreign1",
+        "name": "Foreign Agent",
+        "description": "An agent whose class is not importable in this environment",
+        "class_name": "not_installed.pkg.SomeAgent",
+        "properties": dict(FOREIGN_PROPS),
+    }
+
+
+class TestAgentSpecOpaqueProps:
+    """
+    Isolated per-agent deployments: an environment lacking an agent's package must
+    still deserialize/hold/re-persist that agent's spec, with its properties kept as
+    a lossless OpaqueProps rather than raising. Fail-fast stays available on demand
+    via the ``require_agent_class`` validation context.
+    """
+
+    def test_missing_class_degrades_to_opaque_and_roundtrips(self):
+        spec = AgentSpec.model_validate(_foreign_agent_data())
+
+        assert isinstance(spec.properties, OpaqueProps)
+        # Lossless round-trip, both directly on the props and through the AgentSpec
+        # field (the latter is exercised when a full guild_spec is re-dumped, e.g.
+        # GuildManagerAgent bootstrap / refresh).
+        assert spec.properties.model_dump() == FOREIGN_PROPS
+        assert spec.model_dump()["properties"] == FOREIGN_PROPS
+        # The metastore re-persist path (AgentModel.from_agent_spec -> properties
+        # model_dump) must not narrow or corrupt a peer's stored config.
+        assert AgentModel.from_agent_spec("g1", spec).properties == FOREIGN_PROPS
+
+    def test_strict_context_rejects_missing_class(self):
+        with pytest.raises(ValidationError):
+            AgentSpec.model_validate(_foreign_agent_data(), context={"require_agent_class": True})
+
+    def test_full_guild_with_one_missing_agent_loads(self):
+        guild = GuildSpec.model_validate(
+            {
+                "name": "MixedGuild",
+                "description": "One core agent, one uninstalled agent",
+                "agents": [
+                    {
+                        "id": "core1",
+                        "name": "Core Agent",
+                        "description": "A core agent present in this environment",
+                        "class_name": get_qualified_class_name(SimpleAgent),
+                    },
+                    _foreign_agent_data(),
+                ],
+            }
+        )
+
+        by_id = {a.id: a for a in guild.agents}
+        assert isinstance(by_id["foreign1"].properties, OpaqueProps)
+        assert not isinstance(by_id["core1"].properties, OpaqueProps)
+
+        # The same guild fails fast under strict validation (env expected to have
+        # every agent class, e.g. CI/authoring).
+        with pytest.raises(ValidationError):
+            GuildSpec.model_validate(guild.model_dump(), context={"require_agent_class": True})
+
+    def test_present_class_types_normally(self):
+        spec = AgentSpec[DemoAgentProps](
+            name="Agent1",
+            description="First agent",
+            class_name=get_qualified_class_name(DemoAgentGenericWithoutTypedParams),
+            properties={"prop1": "value1", "prop2": 2},
+        )
+
+        assert not isinstance(spec.properties, OpaqueProps)
+        assert type(spec.props) is DemoAgentProps
+        assert spec.props.prop1 == "value1"
+
+
+class TestAgentSpecNestedPlugins:
+    """
+    The agent class itself is importable, but a nested plugin/toolset class referenced
+    by its props (like a ReActAgent whose toolset lives in a package this environment
+    lacks) is not. Deserialization must still degrade the whole props to OpaqueProps by
+    default, so a container can hold a peer it does not run.
+    """
+
+    def _data(self, param_class: str) -> dict:
+        return {
+            "id": "nested1",
+            "name": "Nested Agent",
+            "description": "Agent whose props reference a nested class",
+            "class_name": get_qualified_class_name(NestedResolvingAgent),
+            "properties": {"param_class": param_class},
+        }
+
+    def test_nested_missing_plugin_degrades_to_opaque(self):
+        spec = AgentSpec.model_validate(self._data("not_installed.pkg.SomeModel"))
+
+        assert isinstance(spec.properties, OpaqueProps)
+        # The unresolved FQCN string is preserved verbatim (never imported).
+        assert spec.properties.model_dump() == {"param_class": "not_installed.pkg.SomeModel"}
+        assert spec.model_dump()["properties"] == {"param_class": "not_installed.pkg.SomeModel"}
+
+    def test_nested_missing_plugin_strict_raises(self):
+        with pytest.raises(ValidationError):
+            AgentSpec.model_validate(
+                self._data("not_installed.pkg.SomeModel"),
+                context={"require_agent_class": True},
+            )
+
+    def test_nested_present_plugin_types_normally(self):
+        spec = AgentSpec.model_validate(self._data(get_qualified_class_name(MessageDataType)))
+
+        assert not isinstance(spec.properties, OpaqueProps)
+        assert spec.props.param_class is MessageDataType
+
+    def test_guild_manager_props_hold_peers_opaque_even_under_strict(self):
+        # A core-only GuildManagerAgent embeds a full guild_spec of peers. Strict
+        # validation of the GMA must NOT require those peers' plugin classes — they
+        # are held opaquely; strictness does not recurse into the embedded guild_spec.
+        foreign = {
+            "id": "peer1",
+            "name": "Peer",
+            "description": "A peer plugin agent not installed here",
+            "class_name": "not_installed.pkg.SomeAgent",
+            "properties": {"x": 1},
+        }
+        gma = {
+            "name": "Guild Manager",
+            "description": "Manages the guild",
+            "class_name": "rustic_ai.core.agents.system.guild_manager_agent.GuildManagerAgent",
+            "properties": {
+                "guild_spec": {"name": "G", "description": "d", "agents": [foreign]},
+                "database_url": "sqlite://",
+                "organization_id": "org1",
+            },
+        }
+
+        spec = AgentSpec.model_validate(gma, context={"require_agent_class": True})
+        peer = spec.props.guild_spec.agents[0]
+        assert isinstance(peer.properties, OpaqueProps)


### PR DESCRIPTION
Enable isolated per-agent deployments where an environment has only a subset of agent packages installed. AgentSpec.pre_build_validator was the sole surface that eagerly imported every agent's class (and each nested plugin/toolset `kind`) on every model_validate, forcing a core-only GuildManagerAgent or API server to install every plugin just to load a guild spec.

pre_build_validator is now tolerant by default: on ImportError resolving class_name OR a nested plugin/toolset class referenced by the props, it degrades the properties to an OpaqueProps container (extra="allow") that preserves the raw dict losslessly (round-trips via model_dump and through AgentModel.from_agent_spec). Malformed names, non-Agent classes, and bad prop values still raise. Fail-fast is opt-in via
context={"require_agent_class": True}, exposed as
GuildBuilder.validate_deployable() for CI/authoring; it does not recurse into an agent's embedded specs, so a core-only GuildManagerAgent validates strictly while its nested guild_spec peers stay tolerantly opaque.

build_agent_from_spec re-validates strictly only when the props arrived opaque, re-typing a spec shipped from a core-only manager and failing fast if the running environment lacks its own agent's deps; specs whose props are already typed are left untouched to preserve live plugin instance identity.

Also removes a no-op GuildSpec.__init__ that silently dropped pydantic's validation context for nested agents.